### PR TITLE
add `set` method to assign key/value pairs

### DIFF
--- a/createHashMap.mjs
+++ b/createHashMap.mjs
@@ -1,5 +1,8 @@
+import createLinkedList from "./createLinkedList.mjs";
+
 export default function createHashMap() {
   let bucketSize = 16;
+  const buckets = new Array(bucketSize).fill(createLinkedList());
 
   const hash = (key) => {
     const keyIsString = typeof key === "string" || key instanceof String;

--- a/createHashMap.mjs
+++ b/createHashMap.mjs
@@ -16,6 +16,15 @@ export default function createHashMap() {
   };
 
   const set = (key, value) => {
+    const hashCode = hash(key);
+
+    // find bucket at index of hashcode
+
+    // store key/value pair in bucket
+
+    // if there is already the _same key_, we overwrite
+
+    // if there is not the same key already, we append to linkedlist
     return;
   };
 

--- a/createHashMap.mjs
+++ b/createHashMap.mjs
@@ -1,11 +1,12 @@
 export default function createHashMap() {
+  let bucketSize = 16;
+
   const hash = (key) => {
     const keyIsString = typeof key === "string" || key instanceof String;
     if (!keyIsString) key = String(key);
 
     let hashCode = 0;
     const PRIME_NUMBER = 31;
-    let bucketSize = 16;
 
     for (let i = 0; i < key.length; i++) {
       hashCode = (PRIME_NUMBER * hashCode + key.charCodeAt(i)) % bucketSize;
@@ -14,5 +15,9 @@ export default function createHashMap() {
     return hashCode;
   };
 
-  return { hash };
+  const set = (key, value) => {
+    return;
+  };
+
+  return { hash, set };
 }

--- a/createHashMap.mjs
+++ b/createHashMap.mjs
@@ -20,14 +20,17 @@ export default function createHashMap() {
 
   const set = (key, value) => {
     const hashCode = hash(key);
-
-    // find bucket at index of hashcode
+    const bucket = buckets[hashCode];
 
     // store key/value pair in bucket
 
     // if there is already the _same key_, we overwrite
 
     // if there is not the same key already, we append to linkedlist
+    bucket.append(value);
+
+    console.log(bucket.print());
+
     return;
   };
 

--- a/createHashMap.mjs
+++ b/createHashMap.mjs
@@ -1,5 +1,8 @@
+import createLinkedList from "./createLinkedList.mjs";
+
 export default function createHashMap() {
   let bucketSize = 16;
+  const buckets = new Array(bucketSize).fill(createLinkedList());
 
   const hash = (key) => {
     const keyIsString = typeof key === "string" || key instanceof String;
@@ -16,7 +19,12 @@ export default function createHashMap() {
   };
 
   const set = (key, value) => {
-    return;
+    const hashCode = hash(key);
+    const bucket = buckets[hashCode];
+
+    const duplicateNode = bucket.findNode(key);
+    if (duplicateNode) duplicateNode.value = value;
+    else bucket.append(key, value);
   };
 
   return { hash, set };

--- a/createLinkedList.mjs
+++ b/createLinkedList.mjs
@@ -3,10 +3,25 @@ import createNode from "./createNode.mjs";
 export default function createLinkedList() {
   let headNode = null;
 
-  const append = (val) => {
-    const newNode = createNode(val);
+  const findNode = (key) => {
+    if (headNode === null) return null;
 
-    if (headNode === null) return (headNode = newNode);
+    let currentNode = headNode;
+    while (currentNode) {
+      if (currentNode.key === key) return currentNode;
+      currentNode = currentNode.nextNode;
+    }
+
+    return null;
+  };
+
+  const append = (key, value) => {
+    const newNode = createNode(key, value);
+
+    if (headNode === null) {
+      headNode = newNode;
+      return;
+    }
 
     let currentNode = headNode;
     while (currentNode.nextNode !== null) currentNode = currentNode.nextNode;
@@ -19,7 +34,7 @@ export default function createLinkedList() {
 
     let currentNode = headNode;
     while (currentNode) {
-      res += `( ${currentNode.value} ) -> `;
+      res += `( ${currentNode.key}: ${currentNode.value} ) -> `;
       currentNode = currentNode.nextNode;
     }
     res += "null";
@@ -28,5 +43,5 @@ export default function createLinkedList() {
     return res;
   };
 
-  return { append, print };
+  return { append, findNode, print };
 }

--- a/createLinkedList.mjs
+++ b/createLinkedList.mjs
@@ -1,3 +1,32 @@
+import createNode from "./createNode.mjs";
+
 export default function createLinkedList() {
-  return;
+  let headNode = null;
+
+  const append = (val) => {
+    const newNode = createNode(val);
+
+    if (headNode === null) return (headNode = newNode);
+
+    let currentNode = headNode;
+    while (currentNode.nextNode !== null) currentNode = currentNode.nextNode;
+    currentNode.nextNode = newNode;
+  };
+
+  const print = () => {
+    let res = "";
+    if (headNode === null) return "null";
+
+    let currentNode = headNode;
+    while (currentNode) {
+      res += `( ${currentNode.value} ) -> `;
+      currentNode = currentNode.nextNode;
+    }
+    res += "null";
+
+    console.log(res);
+    return res;
+  };
+
+  return { append, print };
 }

--- a/createLinkedList.mjs
+++ b/createLinkedList.mjs
@@ -1,0 +1,3 @@
+export default function createLinkedList() {
+  return;
+}

--- a/createNode.mjs
+++ b/createNode.mjs
@@ -1,6 +1,5 @@
-export default function createNode(val) {
-  const value = val || null;
+export default function createNode(key, value) {
   const nextNode = null;
-  
-  return { value, nextNode };
+
+  return { key, value, nextNode };
 }

--- a/createNode.mjs
+++ b/createNode.mjs
@@ -1,3 +1,6 @@
-export default function createNode(value) {
-  return;
+export default function createNode(val) {
+  const value = val || null;
+  const nextNode = null;
+  
+  return { value, nextNode };
 }

--- a/createNode.mjs
+++ b/createNode.mjs
@@ -1,0 +1,3 @@
+export default function createNode(value) {
+  return;
+}

--- a/index.mjs
+++ b/index.mjs
@@ -1,10 +1,7 @@
 import createHashMap from "./createHashMap.mjs";
-import createLinkedList from "./createLinkedList.mjs";
 
 const hashMap = createHashMap();
 console.log(hashMap.hash("heooll"));
-
-const list = createLinkedList();
-list.append(1);
-list.append(2);
-list.print();
+console.log(hashMap.set("harry", "potter"));
+console.log(hashMap.set("Severus", "Snape"));
+console.log(hashMap.set("harry", "the prince")); // previous entry should be overwritten

--- a/index.mjs
+++ b/index.mjs
@@ -1,10 +1,4 @@
 import createHashMap from "./createHashMap.mjs";
-import createLinkedList from "./createLinkedList.mjs";
 
 const hashMap = createHashMap();
 console.log(hashMap.hash("heooll"));
-
-const list = createLinkedList();
-list.append(1);
-list.append(2);
-list.print();

--- a/index.mjs
+++ b/index.mjs
@@ -1,4 +1,10 @@
 import createHashMap from "./createHashMap.mjs";
+import createLinkedList from "./createLinkedList.mjs";
 
 const hashMap = createHashMap();
 console.log(hashMap.hash("heooll"));
+
+const list = createLinkedList();
+list.append(1);
+list.append(2);
+list.print();

--- a/index.mjs
+++ b/index.mjs
@@ -2,3 +2,4 @@ import createHashMap from "./createHashMap.mjs";
 
 const hashMap = createHashMap();
 console.log(hashMap.hash("heooll"));
+console.log(hashMap.set("griffindor", "harry"));


### PR DESCRIPTION
fixes partially #1 - does not fully fix as this PR does not include expanding the buckets (issue #5)

implements linked list structure as the values in a bucket; handles scenario where the same key is present in the same bucket (overrides old value)