### PR TITLE
Fix: properly set key value pairs in their right buckets

### DIFF
--- a/createHashMap.mjs
+++ b/createHashMap.mjs
@@ -2,7 +2,7 @@ import createLinkedList from "./createLinkedList.mjs";
 
 export default function createHashMap() {
   let bucketSize = 16;
-  const buckets = new Array(bucketSize).fill(createLinkedList());
+  const buckets = Array.from({ length: bucketSize }, () => createLinkedList());
 
   const hash = (key) => {
     const keyIsString = typeof key === "string" || key instanceof String;
@@ -25,12 +25,14 @@ export default function createHashMap() {
     const duplicateNode = bucket.findNode(key);
     if (duplicateNode) duplicateNode.value = value;
     else bucket.append(key, value);
+
+    bucket.print();
   };
 
   const print = () => {
     buckets.forEach((bucket, hashCode) => {
       console.log("bucket:", hashCode);
-      bucket.print();
+      if (bucket) bucket.print();
     });
   };
 

--- a/createHashMap.mjs
+++ b/createHashMap.mjs
@@ -25,16 +25,12 @@ export default function createHashMap() {
     const duplicateNode = bucket.findNode(key);
     if (duplicateNode) duplicateNode.value = value;
     else bucket.append(key, value);
-
-    bucket.print();
   };
 
-  const print = () => {
-    buckets.forEach((bucket, hashCode) => {
-      console.log("bucket:", hashCode);
-      if (bucket) bucket.print();
-    });
-  };
+  const print = () =>
+    buckets.forEach((bucket, hashCode) =>
+      console.log("bucket:", hashCode, bucket.toString())
+    );
 
   return { hash, set, print };
 }

--- a/createHashMap.mjs
+++ b/createHashMap.mjs
@@ -27,5 +27,12 @@ export default function createHashMap() {
     else bucket.append(key, value);
   };
 
-  return { hash, set };
+  const print = () => {
+    buckets.forEach((bucket, hashCode) => {
+      console.log("bucket:", hashCode);
+      bucket.print();
+    });
+  };
+
+  return { hash, set, print };
 }

--- a/createLinkedList.mjs
+++ b/createLinkedList.mjs
@@ -28,7 +28,7 @@ export default function createLinkedList() {
     currentNode.nextNode = newNode;
   };
 
-  const print = () => {
+  const toString = () => {
     let res = "";
     if (headNode === null) return "null";
 
@@ -39,9 +39,8 @@ export default function createLinkedList() {
     }
     res += "null";
 
-    console.log(res);
     return res;
   };
 
-  return { append, findNode, print };
+  return { append, findNode, toString };
 }

--- a/index.mjs
+++ b/index.mjs
@@ -6,4 +6,4 @@ hashMap.set("harry", "potter");
 hashMap.set("Severus", "Snape");
 hashMap.set("harry", "the prince"); // previous entry should be overwritten
 
-hashMap.print()
+hashMap.print();

--- a/index.mjs
+++ b/index.mjs
@@ -2,6 +2,8 @@ import createHashMap from "./createHashMap.mjs";
 
 const hashMap = createHashMap();
 
-console.log(hashMap.set("harry", "potter"));
-console.log(hashMap.set("Severus", "Snape"));
-console.log(hashMap.set("harry", "the prince")); // previous entry should be overwritten
+hashMap.set("harry", "potter");
+hashMap.set("Severus", "Snape");
+hashMap.set("harry", "the prince"); // previous entry should be overwritten
+
+hashMap.print()

--- a/index.mjs
+++ b/index.mjs
@@ -1,7 +1,7 @@
 import createHashMap from "./createHashMap.mjs";
 
 const hashMap = createHashMap();
-console.log(hashMap.hash("heooll"));
+
 console.log(hashMap.set("harry", "potter"));
 console.log(hashMap.set("Severus", "Snape"));
 console.log(hashMap.set("harry", "the prince")); // previous entry should be overwritten


### PR DESCRIPTION
fixes #7, which came from #2

core issue was the initialisation of buckets previously meant that every single bucket was referencing the _same_ linked list instance

also added a `.print()` method for the hashmap to print out every bucket