### PR TITLE
get the values in the hashmap, in each of the buckets with `values()` method. fix bug with `.keys()` implementation where it created a 2D array instead of 1D.

### DIFF
--- a/createHashMap.mjs
+++ b/createHashMap.mjs
@@ -26,18 +26,6 @@ export default function createHashMap() {
     return count;
   };
 
-  const keys = () => {
-    const res = [];
-
-    for (let i = 0; i < bucketSize; i++) {
-      const bucket = buckets[i];
-      if (bucket.isEmpty()) continue;
-      res.push(bucket.getKeys());
-    }
-
-    return res;
-  };
-
   const set = (key, value) => {
     const hashCode = hash(key);
     const bucket = buckets[hashCode];
@@ -73,6 +61,30 @@ export default function createHashMap() {
     }
   };
 
+  const keys = () => {
+    const res = [];
+
+    for (let i = 0; i < bucketSize; i++) {
+      const bucket = buckets[i];
+      if (bucket.isEmpty()) continue;
+      res.push(bucket.getKeys());
+    }
+
+    return res;
+  };
+
+  const values = () => {
+    const res = [];
+
+    for (let i = 0; i < bucketSize; i++) {
+      const bucket = buckets[i];
+      if (bucket.isEmpty()) continue;
+      res.push(bucket.getValues());
+    }
+
+    return res;
+  };
+
   const entries = () => {
     const res = [];
 
@@ -93,5 +105,17 @@ export default function createHashMap() {
       console.log("bucket:", hashCode, bucket.toString())
     );
 
-  return { clear, entries, get, has, hash, keys, length, print, remove, set };
+  return {
+    clear,
+    entries,
+    get,
+    has,
+    hash,
+    keys,
+    length,
+    print,
+    remove,
+    set,
+    values,
+  };
 }

--- a/createHashMap.mjs
+++ b/createHashMap.mjs
@@ -67,7 +67,7 @@ export default function createHashMap() {
     for (let i = 0; i < bucketSize; i++) {
       const bucket = buckets[i];
       if (bucket.isEmpty()) continue;
-      res.push(bucket.getKeys());
+      res.push(...bucket.getKeys());
     }
 
     return res;
@@ -79,7 +79,7 @@ export default function createHashMap() {
     for (let i = 0; i < bucketSize; i++) {
       const bucket = buckets[i];
       if (bucket.isEmpty()) continue;
-      res.push(bucket.getValues());
+      res.push(...bucket.getValues());
     }
 
     return res;

--- a/createLinkedList.mjs
+++ b/createLinkedList.mjs
@@ -82,6 +82,20 @@ export default function createLinkedList() {
     return keys;
   };
 
+  const getValues = () => {
+    const values = [];
+
+    if (isEmpty()) return values;
+
+    let currentNode = headNode;
+    while (currentNode) {
+      values.push(currentNode.value);
+      currentNode = currentNode.nextNode;
+    }
+
+    return values;
+  };
+
   const toString = () => {
     if (isEmpty()) return "null";
 
@@ -101,6 +115,7 @@ export default function createLinkedList() {
     findNode,
     getKeys,
     getKeyValues,
+    getValues,
     isEmpty,
     length,
     removeNode,

--- a/index.mjs
+++ b/index.mjs
@@ -7,6 +7,6 @@ hashMap.set("arrhy", "what is this");
 hashMap.set("Severus", "Snape");
 hashMap.set("harry", "the prince");
 
-console.log(hashMap.keys()); // expected: ["harry", "arrhy", "Severus"]
+console.log(hashMap.values()); // expected: ["the prince", "what is this", "Snape"]
 hashMap.remove("harry");
-console.log(hashMap.keys()); // expected: ["arrhy", "Severus"]
+console.log(hashMap.values()); // expected: ["what is this", "Snape"]


### PR DESCRIPTION
this is implemented by traversing each of the buckets (linked list) within the linked list in the same way as `.keys()` method. although we violate DRY, this avoids having to do 3 loops.

used `...` destructuring syntax to fix bug where 2D array was created with `.keys()` previously, but what was required was a 1D array.

fixes #16 