### PR TITLE
expand the number of buckets to minimise (if not, avoid) collisions. fix `entries()` method creating too deeply nested of an array.

### DIFF
--- a/createHashMap.mjs
+++ b/createHashMap.mjs
@@ -33,10 +33,12 @@ export default function createHashMap() {
     console.log("!!!TIME TO EXPAND!!!");
     bucketSize *= 2;
     console.log("bucketSize:", bucketSize);
+    const newBuckets = generateBuckets();
   };
 
-  const generateBuckets = () =>
-    Array.from({ length: bucketSize }, () => createLinkedList());
+  function generateBuckets() {
+    return Array.from({ length: bucketSize }, () => createLinkedList());
+  }
 
   const length = () => {
     let count = 0;

--- a/createHashMap.mjs
+++ b/createHashMap.mjs
@@ -1,7 +1,7 @@
 import createLinkedList from "./createLinkedList.mjs";
 
 export default function createHashMap() {
-  let bucketSize = 16;
+  let bucketSize = 4;
   let buckets = generateBuckets();
 
   const hash = (key) => {
@@ -110,14 +110,14 @@ export default function createHashMap() {
     for (let i = 0; i < bucketSize; i++) {
       const bucket = buckets[i];
       if (bucket.isEmpty()) continue;
-      res.push(bucket.getKeyValues());
+      res.push(...bucket.getKeyValues());
     }
 
     return res;
   };
 
   const clear = () => {
-    bucketSize = 16;
+    bucketSize = 4;
     buckets = generateBuckets();
   };
 

--- a/createHashMap.mjs
+++ b/createHashMap.mjs
@@ -1,8 +1,9 @@
 import createLinkedList from "./createLinkedList.mjs";
 
 export default function createHashMap() {
-  let bucketSize = 4; // TODO: PUT BACK TO 16
-  let buckets = Array.from({ length: bucketSize }, () => createLinkedList());
+  let bucketSize = 4; // TODO: PUT BACK TO 16 // aka capacity
+  //? getBucketSize() method to handle all the logic? if it's less than 16 (currently, 4, for testing), then just return 16 (take the max of (16, X))
+  let buckets = Array.from({ length: bucketSize }, () => createLinkedList()); //? potentially this can go into a "generateBuckets()" method, which then checks the bucketSize at the time before generating?
 
   const hash = (key) => {
     const keyIsString = typeof key === "string" || key instanceof String;
@@ -18,8 +19,16 @@ export default function createHashMap() {
     return hashCode;
   };
 
-  // TODO: delete
-  const getBucketSize = () => bucketSize;
+  const getBucketSize = () => bucketSize; // TODO: delete
+  const setBucketSize = () => {
+    const LOAD_FACTOR = 0.8; // can be a number between .75 and 1
+    const storedKeysCount = length();
+    const threshold = Math.ceil(LOAD_FACTOR * bucketSize);
+
+    if (storedKeysCount >= threshold) {
+      bucketSize *= 2;
+    }
+  };
 
   const length = () => {
     let count = 0;

--- a/createHashMap.mjs
+++ b/createHashMap.mjs
@@ -1,7 +1,7 @@
 import createLinkedList from "./createLinkedList.mjs";
 
 export default function createHashMap() {
-  let bucketSize = 4;
+  let bucketSize = 16;
   let buckets = generateBuckets();
 
   const hash = (key) => {
@@ -117,7 +117,7 @@ export default function createHashMap() {
   };
 
   const clear = () => {
-    bucketSize = 4;
+    bucketSize = 16;
     buckets = generateBuckets();
   };
 

--- a/createHashMap.mjs
+++ b/createHashMap.mjs
@@ -1,8 +1,7 @@
 import createLinkedList from "./createLinkedList.mjs";
 
 export default function createHashMap() {
-  let bucketSize = 4; // TODO: PUT BACK TO 16 // aka capacity
-  //? getBucketSize() method to handle all the logic? if it's less than 16 (currently, 4, for testing), then just return 16 (take the max of (16, X))
+  let bucketSize = 16;
   let buckets = generateBuckets();
 
   const hash = (key) => {
@@ -19,21 +18,17 @@ export default function createHashMap() {
     return hashCode;
   };
 
-  const getBucketSize = () => bucketSize; // TODO: delete
   const setBucketSize = () => {
     const LOAD_FACTOR = 0.8; // can be a number between .75 and 1
     const storedKeysCount = length();
     const threshold = Math.ceil(LOAD_FACTOR * bucketSize);
 
-    console.log("bucketSize:", bucketSize);
-    console.log("threshold: ", threshold);
-
     if (storedKeysCount < threshold) return;
 
-    console.log("!!!TIME TO EXPAND!!!");
+    const currentEntries = entries();
     bucketSize *= 2;
-    console.log("bucketSize:", bucketSize);
-    const newBuckets = generateBuckets();
+    buckets = generateBuckets();
+    currentEntries.forEach((entry) => set(entry[0], entry[1]));
   };
 
   function generateBuckets() {
@@ -122,7 +117,7 @@ export default function createHashMap() {
   };
 
   const clear = () => {
-    bucketSize = 4; //TODO: change
+    bucketSize = 16;
     buckets = generateBuckets();
   };
 
@@ -135,7 +130,6 @@ export default function createHashMap() {
     clear,
     entries,
     get,
-    getBucketSize,
     has,
     hash,
     keys,

--- a/createHashMap.mjs
+++ b/createHashMap.mjs
@@ -28,11 +28,11 @@ export default function createHashMap() {
     console.log("bucketSize:", bucketSize);
     console.log("threshold: ", threshold);
 
-    if (storedKeysCount >= threshold) {
-      console.log("!!!TIME TO EXPAND!!!");
-      bucketSize *= 2;
-      console.log("bucketSize:", bucketSize);
-    }
+    if (storedKeysCount < threshold) return;
+
+    console.log("!!!TIME TO EXPAND!!!");
+    bucketSize *= 2;
+    console.log("bucketSize:", bucketSize);
   };
 
   const length = () => {

--- a/createHashMap.mjs
+++ b/createHashMap.mjs
@@ -3,7 +3,7 @@ import createLinkedList from "./createLinkedList.mjs";
 export default function createHashMap() {
   let bucketSize = 4; // TODO: PUT BACK TO 16 // aka capacity
   //? getBucketSize() method to handle all the logic? if it's less than 16 (currently, 4, for testing), then just return 16 (take the max of (16, X))
-  let buckets = Array.from({ length: bucketSize }, () => createLinkedList()); //? potentially this can go into a "generateBuckets()" method, which then checks the bucketSize at the time before generating?
+  let buckets = generateBuckets();
 
   const hash = (key) => {
     const keyIsString = typeof key === "string" || key instanceof String;
@@ -34,6 +34,9 @@ export default function createHashMap() {
     bucketSize *= 2;
     console.log("bucketSize:", bucketSize);
   };
+
+  const generateBuckets = () =>
+    Array.from({ length: bucketSize }, () => createLinkedList());
 
   const length = () => {
     let count = 0;
@@ -116,8 +119,10 @@ export default function createHashMap() {
     return res;
   };
 
-  const clear = () =>
-    (buckets = Array.from({ length: bucketSize }, () => createLinkedList()));
+  const clear = () => {
+    bucketSize = 4; //TODO: change
+    buckets = generateBuckets();
+  };
 
   const print = () =>
     buckets.forEach((bucket, hashCode) =>

--- a/createHashMap.mjs
+++ b/createHashMap.mjs
@@ -25,8 +25,13 @@ export default function createHashMap() {
     const storedKeysCount = length();
     const threshold = Math.ceil(LOAD_FACTOR * bucketSize);
 
+    console.log("bucketSize:", bucketSize);
+    console.log("threshold: ", threshold);
+
     if (storedKeysCount >= threshold) {
+      console.log("!!!TIME TO EXPAND!!!");
       bucketSize *= 2;
+      console.log("bucketSize:", bucketSize);
     }
   };
 
@@ -45,6 +50,8 @@ export default function createHashMap() {
     const duplicateNode = bucket.findNode(key);
     if (duplicateNode) duplicateNode.value = value;
     else bucket.append(key, value);
+
+    setBucketSize();
   };
 
   const get = (key) => {

--- a/createHashMap.mjs
+++ b/createHashMap.mjs
@@ -1,7 +1,7 @@
 import createLinkedList from "./createLinkedList.mjs";
 
 export default function createHashMap() {
-  let bucketSize = 16;
+  let bucketSize = 4; // TODO: PUT BACK TO 16
   let buckets = Array.from({ length: bucketSize }, () => createLinkedList());
 
   const hash = (key) => {
@@ -17,6 +17,9 @@ export default function createHashMap() {
 
     return hashCode;
   };
+
+  // TODO: delete
+  const getBucketSize = () => bucketSize;
 
   const length = () => {
     let count = 0;
@@ -109,6 +112,7 @@ export default function createHashMap() {
     clear,
     entries,
     get,
+    getBucketSize,
     has,
     hash,
     keys,

--- a/index.mjs
+++ b/index.mjs
@@ -12,8 +12,8 @@ The current bucket size is ${hashMap.getBucketSize()}`);
 hashMap.print();
 
 hashMap.set("hermione", "granger");
-hashMap.set("ron", "weasley");
+// hashMap.set("ron", "weasley");
 
-console.log(`
-The bucket size is now ${hashMap.getBucketSize()}`);
-hashMap.print();
+// console.log(`
+// The bucket size is now ${hashMap.getBucketSize()}`);
+// hashMap.print();

--- a/index.mjs
+++ b/index.mjs
@@ -7,13 +7,10 @@ hashMap.set("arrhy", "what is this");
 hashMap.set("Severus", "Snape");
 hashMap.set("harry", "the prince");
 
-console.log(`
-The current bucket size is ${hashMap.getBucketSize()}`);
 hashMap.print();
+console.log("----")
 
 hashMap.set("hermione", "granger");
-// hashMap.set("ron", "weasley");
+hashMap.set("ron", "weasley");
 
-console.log(`
-The bucket size is now ${hashMap.getBucketSize()}`);
 hashMap.print();

--- a/index.mjs
+++ b/index.mjs
@@ -6,7 +6,14 @@ hashMap.set("harry", "potter");
 hashMap.set("arrhy", "what is this");
 hashMap.set("Severus", "Snape");
 hashMap.set("harry", "the prince");
+
+console.log(`
+The current bucket size is ${hashMap.getBucketSize()}`);
+hashMap.print();
+
 hashMap.set("hermione", "granger");
 hashMap.set("ron", "weasley");
 
+console.log(`
+The bucket size is now ${hashMap.getBucketSize()}`);
 hashMap.print();

--- a/index.mjs
+++ b/index.mjs
@@ -8,7 +8,7 @@ hashMap.set("Severus", "Snape");
 hashMap.set("harry", "the prince");
 
 hashMap.print();
-console.log("----")
+console.log("----");
 
 hashMap.set("hermione", "granger");
 hashMap.set("ron", "weasley");

--- a/index.mjs
+++ b/index.mjs
@@ -14,6 +14,6 @@ hashMap.print();
 hashMap.set("hermione", "granger");
 // hashMap.set("ron", "weasley");
 
-// console.log(`
-// The bucket size is now ${hashMap.getBucketSize()}`);
-// hashMap.print();
+console.log(`
+The bucket size is now ${hashMap.getBucketSize()}`);
+hashMap.print();

--- a/index.mjs
+++ b/index.mjs
@@ -6,7 +6,7 @@ hashMap.set("harry", "potter");
 hashMap.set("arrhy", "what is this");
 hashMap.set("Severus", "Snape");
 hashMap.set("harry", "the prince");
+hashMap.set("hermione", "granger");
+hashMap.set("ron", "weasley");
 
-console.log(hashMap.values()); // expected: ["the prince", "what is this", "Snape"]
-hashMap.remove("harry");
-console.log(hashMap.values()); // expected: ["what is this", "Snape"]
+hashMap.print();


### PR DESCRIPTION
fixes #5 

# testing
## setup
1. reduced the bucket size from `16` to `4`... (this will be restored)
2. while increasing the total number of nodes to `5`, forcing a collision:
```js
// index.mjs
import createHashMap from "./createHashMap.mjs";

const hashMap = createHashMap();

hashMap.set("harry", "potter");
hashMap.set("arrhy", "what is this");
hashMap.set("Severus", "Snape");
hashMap.set("harry", "the prince");

hashMap.print();
console.log("----");

hashMap.set("hermione", "granger");
hashMap.set("ron", "weasley");

hashMap.print();
```

there is now a collision in bucket 1:
![image](https://github.com/user-attachments/assets/d789ea33-5f01-4dee-9e92-fdda073bf2cd)

3. create a getter method in hashmap factory to get the bucketsize so i can actually test this code (this will be removed)
## results
no more collisions now. we expect that, with the `LOAD_FACTOR` set, that adding hermione's entry would trigger an expansion:
![image](https://github.com/user-attachments/assets/ba2fd31c-9040-4036-9c98-a3476bfe9b9a)